### PR TITLE
Add IterateObjects

### DIFF
--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -18,6 +18,8 @@ import (
 var (
 	// ErrURLNotSupported represents url is not supported
 	ErrURLNotSupported = errors.New("url method not supported")
+	// ErrIterateObjectsNotSupported represents IterateObjects not supported
+	ErrIterateObjectsNotSupported = errors.New("iterateObjects method not supported")
 )
 
 // Object represents the object on the storage
@@ -34,6 +36,7 @@ type ObjectStorage interface {
 	Stat(path string) (os.FileInfo, error)
 	Delete(path string) error
 	URL(path, name string) (*url.URL, error)
+	IterateObjects(func(path string, obj Object) error) error
 }
 
 // Copy copys a file from source ObjectStorage to dest ObjectStorage


### PR DESCRIPTION
This PR adds another Function to iterate the objects on the storage simplifying the dump.go command.

(The exact munging of the paths in IterateObjects needs to be double checked.)