### PR TITLE
Ship esbuild binaries for all platforms in tarball

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -524,7 +524,7 @@ steps:
     pull: always
     image: techknowlogick/xgo:go-1.15.x
     commands:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt -y install nodejs
+      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt -y install nodejs bsdtar\|libarchive-tools
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:
@@ -620,7 +620,7 @@ steps:
     pull: always
     image: techknowlogick/xgo:go-1.15.x
     commands:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt -y install nodejs
+      - curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt -y install nodejs bsdtar\|libarchive-tools
       - export PATH=$PATH:$GOPATH/bin
       - make release
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ coverage.all
 /public/css
 /public/fonts
 /public/img/webpack
+/web_src/fomantic/node_modules
+/web_src/fomantic/.npmrc
+/web_src/fomantic/semantic.json
 /web_src/fomantic/build/*
 !/web_src/fomantic/build/semantic.js
 !/web_src/fomantic/build/semantic.css
@@ -93,6 +96,7 @@ coverage.all
 !/web_src/fomantic/build/themes/default/assets/fonts/outline-icons.woff2
 /VERSION
 /.air
+/.npm-cache
 
 # Snapcraft
 snap/.snapcraft/

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ audit=false
 fund=false
 package-lock=true
 save-exact=true
+cache=.npm-cache

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ GO_PACKAGES ?= $(filter-out code.gitea.io/gitea/integrations/migration-test,$(fi
 
 FOMANTIC_CONFIGS := semantic.json web_src/fomantic/theme.config.less web_src/fomantic/_site/globals/site.variables
 FOMANTIC_DEST := web_src/fomantic/build/semantic.js web_src/fomantic/build/semantic.css
-FOMANTIC_DEST_DIR := web_src/fomantic/build
+FOMANTIC_WORK_DIR := web_src/fomantic
 
 WEBPACK_SOURCES := $(shell find web_src/js web_src/less -type f)
 WEBPACK_CONFIGS := webpack.config.js
@@ -615,9 +615,9 @@ release-compress: | $(DIST_DIRS)
 	cd $(DIST)/release/; for file in `find . -type f -name "*"`; do echo "compressing $${file}" && gxz -k -9 $${file}; done;
 
 .PHONY: release-sources
-release-sources: | $(DIST_DIRS) node_modules
+release-sources: | $(DIST_DIRS) npm-cache
 	echo $(VERSION) > $(STORED_VERSION_FILE)
-	tar --exclude=./$(DIST) --exclude=./.git --exclude=./$(MAKE_EVIDENCE_DIR) --exclude=./node_modules/.cache --exclude=./$(AIR_TMP_DIR) -czf $(DIST)/release/gitea-src-$(VERSION).tar.gz .
+	tar --exclude=./$(DIST) --exclude=./.git --exclude=./$(MAKE_EVIDENCE_DIR) --exclude=./node_modules --exclude=./$(AIR_TMP_DIR) -czf $(DIST)/release/gitea-src-$(VERSION).tar.gz .
 	rm -f $(STORED_VERSION_FILE)
 
 .PHONY: release-docs
@@ -635,6 +635,26 @@ node_modules: package-lock.json
 	npm install --no-save
 	@touch node_modules
 
+.PHONY: npm-cache
+npm-cache: .npm-cache $(FOMANTIC_WORK_DIR)/node_modules/fomantic-ui
+
+.npm-cache: package-lock.json
+	rm -rf .npm-cache
+	$(eval ESBUILD_VERSION := `node -p "require('./package-lock.json').dependencies.esbuild.version"`)
+	$(eval ESBUILD_PKGS := esbuild-{darwin-64,linux-{arm,arm64,32,64},windows-{32,64}}@$(ESBUILD_VERSION))
+	npm config --userconfig=.npmrc set cache=.npm-cache
+	rm -rf node_modules && npm install --no-save
+	npm config --userconfig=$(FOMANTIC_WORK_DIR)/.npmrc set cache=../../.npm-cache
+	echo $(ESBUILD_PKGS) fsevents@1 fsevents@2 | tr " " "\n" | xargs -n 1 -P 4 npm cache add
+	rm -rf $(FOMANTIC_WORK_DIR)/node_modules
+	@touch .npm-cache
+
+.PHONY: npm-uncache
+npm-uncache:
+	rm -rf .npm-cache
+	rm -f $(FOMANTIC_WORK_DIR)/.npmrc
+	npm config --userconfig=.npmrc rm cache
+
 .PHONY: npm-update
 npm-update: node-check | node_modules
 	npx updates -cu
@@ -645,14 +665,22 @@ npm-update: node-check | node_modules
 .PHONY: fomantic
 fomantic: $(FOMANTIC_DEST)
 
-$(FOMANTIC_DEST): $(FOMANTIC_CONFIGS) | node_modules
-	@if [ ! -d node_modules/fomantic-ui ]; then \
-		npm install --no-save --no-package-lock fomantic-ui@2.8.7; \
-	fi
-	rm -rf $(FOMANTIC_DEST_DIR)
-	cp -f web_src/fomantic/theme.config.less node_modules/fomantic-ui/src/theme.config
-	cp -rf web_src/fomantic/_site/* node_modules/fomantic-ui/src/_site/
-	npx gulp -f node_modules/fomantic-ui/gulpfile.js build
+$(FOMANTIC_WORK_DIR)/node_modules/fomantic-ui:
+	ln -sf ../../semantic.json $(FOMANTIC_WORK_DIR)
+	cd $(FOMANTIC_WORK_DIR); \
+		rm -rf node_modules && mkdir node_modules && \
+		npm install less@3 fomantic-ui --no-package-lock; \
+		rm -f semantic.json
+	@touch $(FOMANTIC_WORK_DIR)/node_modules
+
+$(FOMANTIC_DEST): $(FOMANTIC_CONFIGS) $(FOMANTIC_WORK_DIR)/node_modules/fomantic-ui
+	ln -sf ../../semantic.json $(FOMANTIC_WORK_DIR)
+	rm -rf $(FOMANTIC_WORK_DIR)/build
+	cd $(FOMANTIC_WORK_DIR); \
+		cp -f theme.config.less node_modules/fomantic-ui/src/theme.config; \
+		cp -rf _site node_modules/fomantic-ui/src/; \
+		npx gulp -f node_modules/fomantic-ui/gulpfile.js build; \
+		rm -f semantic.json
 	@touch $(FOMANTIC_DEST)
 
 .PHONY: webpack

--- a/Makefile
+++ b/Makefile
@@ -617,7 +617,7 @@ release-compress: | $(DIST_DIRS)
 .PHONY: release-sources
 release-sources: | $(DIST_DIRS) npm-cache
 	echo $(VERSION) > $(STORED_VERSION_FILE)
-	tar --exclude=./$(DIST) --exclude=./.git --exclude=./$(MAKE_EVIDENCE_DIR) --exclude=./node_modules --exclude=./$(AIR_TMP_DIR) -czf $(DIST)/release/gitea-src-$(VERSION).tar.gz .
+	bsdtar --exclude=^./$(DIST) --exclude=^./.git --exclude=^./$(MAKE_EVIDENCE_DIR) --exclude=node_modules --exclude=^./$(AIR_TMP_DIR) -czf $(DIST)/release/gitea-src-$(VERSION).tar.gz .
 	rm -f $(STORED_VERSION_FILE)
 
 .PHONY: release-docs

--- a/semantic.json
+++ b/semantic.json
@@ -9,12 +9,12 @@
       "themes": "src/themes/"
     },
     "output": {
-      "packaged": "../../web_src/fomantic/build/",
-      "uncompressed": "../../web_src/fomantic/build/components/",
-      "compressed": "../../web_src/fomantic/build/components/",
-      "themes": "../../web_src/fomantic/build/themes/"
+      "packaged": "../../build/",
+      "uncompressed": "../../build/components/",
+      "compressed": "../../build/components/",
+      "themes": "../../build/themes/"
     },
-    "clean": "../../web_src/fomantic/build/"
+    "clean": "../../build/"
   },
   "permission": false,
   "autoInstall": false,


### PR DESCRIPTION
Tested working on macOS and Windows without Internet connection, both for building and for releasing.

Note that testing with npx shows that even without binary file installed into `node_modules/esbuild/bin` and `node_modules/.bin`, having a native subpackage installed would suffice in most cases.

And `esbuild` does not provide a mips64 binary, so good that we've already deprecated that.

I won't be able to do further testing as I happened to have a workplace partition with useful data wiped out on a SSD and thus have to deal with file recovery for that machine first. Sorry for that. Any improvement to the `Makefile` is highly appreciated.